### PR TITLE
Add RSA key import/export and ciphertext file exchange

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,13 +3,18 @@
 from __future__ import annotations
 
 import tkinter as tk
-from tkinter import messagebox, ttk
+from tkinter import filedialog, messagebox, ttk
 
 from feistel_cipher import FeedbackMode, decrypt_text, encrypt_text
 from hybrid_crypto import (
-    RSAKeyPair,
+    RSAPrivateKey,
+    RSAPublicKey,
+    export_rsa_private_key,
+    export_rsa_public_key,
     generate_rsa_keypair,
     generate_secret_key,
+    import_rsa_private_key,
+    import_rsa_public_key,
     rsa_decrypt,
     rsa_encrypt,
 )
@@ -33,7 +38,8 @@ class FeistelApp(tk.Tk):
         self.rsa_private_var = tk.StringVar()
         self.rsa_cipher_var = tk.StringVar()
 
-        self.rsa_keypair: RSAKeyPair | None = None
+        self.rsa_public_key: RSAPublicKey | None = None
+        self.rsa_private_key: RSAPrivateKey | None = None
 
         self._build_widgets()
         self._generate_initial_key()
@@ -106,11 +112,36 @@ class FeistelApp(tk.Tk):
             row=2, column=1, columnspan=2, sticky="w"
         )
 
+        cipher_file_frame = ttk.Frame(crypto_frame)
+        cipher_file_frame.grid(row=3, column=0, columnspan=3, sticky="w", pady=5)
+
+        ttk.Button(cipher_file_frame, text="Импорт шифртекста", command=self._import_ciphertext).grid(
+            row=0, column=0, padx=5
+        )
+        ttk.Button(cipher_file_frame, text="Экспорт шифртекста", command=self._export_ciphertext).grid(
+            row=0, column=1, padx=5
+        )
+
         rsa_frame = ttk.LabelFrame(self, text="Гибридная криптосистема (RSA)")
         rsa_frame.grid(row=3, column=0, sticky="ew", **padding)
 
-        ttk.Button(rsa_frame, text="Сгенерировать RSA ключи", command=self._generate_rsa_keys).grid(
-            row=0, column=0, padx=5, pady=5, sticky="w"
+        rsa_buttons = ttk.Frame(rsa_frame)
+        rsa_buttons.grid(row=0, column=0, columnspan=2, sticky="w", pady=5)
+
+        ttk.Button(rsa_buttons, text="Сгенерировать RSA ключи", command=self._generate_rsa_keys).grid(
+            row=0, column=0, padx=5, pady=2, sticky="w"
+        )
+        ttk.Button(rsa_buttons, text="Импорт публичного ключа", command=self._import_public_key).grid(
+            row=0, column=1, padx=5, pady=2, sticky="w"
+        )
+        ttk.Button(rsa_buttons, text="Импорт приватного ключа", command=self._import_private_key).grid(
+            row=0, column=2, padx=5, pady=2, sticky="w"
+        )
+        ttk.Button(rsa_buttons, text="Экспорт публичного ключа", command=self._export_public_key).grid(
+            row=1, column=0, padx=5, pady=2, sticky="w"
+        )
+        ttk.Button(rsa_buttons, text="Экспорт приватного ключа", command=self._export_private_key).grid(
+            row=1, column=1, padx=5, pady=2, sticky="w"
         )
 
         ttk.Label(rsa_frame, text="Модуль n:").grid(row=1, column=0, sticky="w")
@@ -142,6 +173,12 @@ class FeistelApp(tk.Tk):
         ttk.Button(actions_frame, text="Расшифровать ключ", command=self._decrypt_secret_key).grid(
             row=0, column=1, padx=5
         )
+        ttk.Button(actions_frame, text="Импорт шифртекста ключа", command=self._import_rsa_cipher).grid(
+            row=1, column=0, padx=5, pady=(5, 0)
+        )
+        ttk.Button(actions_frame, text="Экспорт шифртекста ключа", command=self._export_rsa_cipher).grid(
+            row=1, column=1, padx=5, pady=(5, 0)
+        )
 
     # ------------------------------------------------------------------
     # Secret key and RSA helpers
@@ -163,6 +200,30 @@ class FeistelApp(tk.Tk):
 
         self.secret_key_var.set(str(value))
 
+    def _update_rsa_modulus_display(self) -> None:
+        """Обновить поле с модулем RSA."""
+
+        modulus: int | None = None
+        if self.rsa_public_key is not None:
+            modulus = self.rsa_public_key.modulus
+        elif self.rsa_private_key is not None:
+            modulus = self.rsa_private_key.modulus
+        self.rsa_modulus_var.set(str(modulus) if modulus is not None else "")
+
+    def _set_public_key(self, key: RSAPublicKey | None) -> None:
+        """Сохранить публичный ключ и обновить интерфейс."""
+
+        self.rsa_public_key = key
+        self.rsa_public_var.set(str(key.exponent) if key else "")
+        self._update_rsa_modulus_display()
+
+    def _set_private_key(self, key: RSAPrivateKey | None) -> None:
+        """Сохранить приватный ключ и обновить интерфейс."""
+
+        self.rsa_private_key = key
+        self.rsa_private_var.set(str(key.exponent) if key else "")
+        self._update_rsa_modulus_display()
+
     def _get_secret_key(self) -> int:
         """Read and validate the user supplied secret key."""
 
@@ -178,17 +239,138 @@ class FeistelApp(tk.Tk):
     def _generate_rsa_keys(self) -> None:
         """Create a new RSA key pair and show its parameters."""
 
-        self.rsa_keypair = generate_rsa_keypair()
-        self.rsa_modulus_var.set(str(self.rsa_keypair.public.modulus))
-        self.rsa_public_var.set(str(self.rsa_keypair.public.exponent))
-        self.rsa_private_var.set(str(self.rsa_keypair.private.exponent))
+        keypair = generate_rsa_keypair()
+        self._set_public_key(keypair.public)
+        self._set_private_key(keypair.private)
+        self.rsa_cipher_var.set("")
         messagebox.showinfo("RSA", "Создана новая пара RSA ключей.")
+
+    def _import_public_key(self) -> None:
+        """Загрузить публичный RSA ключ из файла."""
+
+        path = filedialog.askopenfilename(
+            title="Импорт публичного ключа",
+            filetypes=[("JSON файлы", "*.json"), ("Все файлы", "*.*")],
+        )
+        if not path:
+            return
+
+        try:
+            with open(path, "r", encoding="utf-8") as handle:
+                data = handle.read()
+        except OSError as error:
+            messagebox.showerror("Ошибка", f"Не удалось прочитать файл: {error}")
+            return
+
+        try:
+            public_key = import_rsa_public_key(data)
+        except ValueError as error:
+            messagebox.showerror("Ошибка", str(error))
+            return
+
+        if (
+            self.rsa_private_key is not None
+            and self.rsa_private_key.modulus != public_key.modulus
+        ):
+            messagebox.showerror(
+                "Ошибка",
+                "Модули публичного и приватного ключей не совпадают.",
+            )
+            return
+
+        self._set_public_key(public_key)
+        messagebox.showinfo("Готово", "Публичный ключ импортирован.")
+
+    def _export_public_key(self) -> None:
+        """Сохранить публичный RSA ключ в файл."""
+
+        if self.rsa_public_key is None:
+            messagebox.showerror("Ошибка", "Нет публичного ключа для экспорта.")
+            return
+
+        path = filedialog.asksaveasfilename(
+            title="Экспорт публичного ключа",
+            defaultextension=".json",
+            filetypes=[("JSON файлы", "*.json"), ("Все файлы", "*.*")],
+        )
+        if not path:
+            return
+
+        try:
+            with open(path, "w", encoding="utf-8") as handle:
+                handle.write(export_rsa_public_key(self.rsa_public_key))
+        except OSError as error:
+            messagebox.showerror("Ошибка", f"Не удалось сохранить файл: {error}")
+            return
+
+        messagebox.showinfo("Готово", "Публичный ключ сохранён.")
+
+    def _import_private_key(self) -> None:
+        """Загрузить приватный RSA ключ из файла."""
+
+        path = filedialog.askopenfilename(
+            title="Импорт приватного ключа",
+            filetypes=[("JSON файлы", "*.json"), ("Все файлы", "*.*")],
+        )
+        if not path:
+            return
+
+        try:
+            with open(path, "r", encoding="utf-8") as handle:
+                data = handle.read()
+        except OSError as error:
+            messagebox.showerror("Ошибка", f"Не удалось прочитать файл: {error}")
+            return
+
+        try:
+            private_key = import_rsa_private_key(data)
+        except ValueError as error:
+            messagebox.showerror("Ошибка", str(error))
+            return
+
+        if (
+            self.rsa_public_key is not None
+            and self.rsa_public_key.modulus != private_key.modulus
+        ):
+            messagebox.showerror(
+                "Ошибка",
+                "Модули публичного и приватного ключей не совпадают.",
+            )
+            return
+
+        self._set_private_key(private_key)
+        self.rsa_cipher_var.set("")
+        messagebox.showinfo("Готово", "Приватный ключ импортирован.")
+
+    def _export_private_key(self) -> None:
+        """Сохранить приватный RSA ключ в файл."""
+
+        if self.rsa_private_key is None:
+            messagebox.showerror("Ошибка", "Нет приватного ключа для экспорта.")
+            return
+
+        path = filedialog.asksaveasfilename(
+            title="Экспорт приватного ключа",
+            defaultextension=".json",
+            filetypes=[("JSON файлы", "*.json"), ("Все файлы", "*.*")],
+        )
+        if not path:
+            return
+
+        try:
+            with open(path, "w", encoding="utf-8") as handle:
+                handle.write(export_rsa_private_key(self.rsa_private_key))
+        except OSError as error:
+            messagebox.showerror("Ошибка", f"Не удалось сохранить файл: {error}")
+            return
+
+        messagebox.showinfo("Готово", "Приватный ключ сохранён.")
 
     def _encrypt_secret_key(self) -> None:
         """Encrypt the Feistel secret key with the RSA public key."""
 
-        if self.rsa_keypair is None:
-            messagebox.showerror("Ошибка", "Сначала сгенерируйте RSA ключи.")
+        if self.rsa_public_key is None:
+            messagebox.showerror("Ошибка", "Нет публичного ключа для шифрования.")
             return
 
         try:
@@ -197,14 +379,14 @@ class FeistelApp(tk.Tk):
             messagebox.showerror("Ошибка", str(error))
             return
 
-        cipher_value = rsa_encrypt(secret_key, self.rsa_keypair.public)
+        cipher_value = rsa_encrypt(secret_key, self.rsa_public_key)
         self.rsa_cipher_var.set(str(cipher_value))
         messagebox.showinfo("Готово", "Ключ зашифрован и готов к передаче.")
 
     def _decrypt_secret_key(self) -> None:
         """Decrypt the RSA encrypted secret key and load it into the field."""
 
-        if self.rsa_keypair is None:
+        if self.rsa_private_key is None:
             messagebox.showerror("Ошибка", "Нет приватного ключа для расшифровки.")
             return
 
@@ -220,13 +402,127 @@ class FeistelApp(tk.Tk):
             return
 
         try:
-            secret_key = rsa_decrypt(cipher_value, self.rsa_keypair.private)
+            secret_key = rsa_decrypt(cipher_value, self.rsa_private_key)
         except ValueError as error:
             messagebox.showerror("Ошибка", str(error))
             return
 
         self._set_secret_key(secret_key)
         messagebox.showinfo("Готово", "Секретный ключ восстановлен.")
+
+    # ------------------------------------------------------------------
+    # Импорт/экспорт данных
+    # ------------------------------------------------------------------
+
+    def _import_rsa_cipher(self) -> None:
+        """Загрузить шифртекст секретного ключа из файла."""
+
+        path = filedialog.askopenfilename(
+            title="Импорт шифртекста ключа",
+            filetypes=[("Текстовые файлы", "*.txt"), ("Все файлы", "*.*")],
+        )
+        if not path:
+            return
+
+        try:
+            with open(path, "r", encoding="utf-8") as handle:
+                raw = handle.read().strip()
+        except OSError as error:
+            messagebox.showerror("Ошибка", f"Не удалось прочитать файл: {error}")
+            return
+
+        if not raw:
+            messagebox.showerror("Ошибка", "Файл не содержит шифртекст.")
+            return
+
+        try:
+            int(raw)
+        except ValueError:
+            messagebox.showerror("Ошибка", "В файле должен быть числовой шифртекст.")
+            return
+
+        self.rsa_cipher_var.set(raw)
+        messagebox.showinfo("Готово", "Шифртекст ключа импортирован.")
+
+    def _export_rsa_cipher(self) -> None:
+        """Сохранить шифртекст секретного ключа в файл."""
+
+        raw = self.rsa_cipher_var.get().strip()
+        if not raw:
+            messagebox.showerror("Ошибка", "Нет шифртекста для экспорта.")
+            return
+
+        try:
+            int(raw)
+        except ValueError:
+            messagebox.showerror("Ошибка", "Шифртекст ключа должен быть числом.")
+            return
+
+        path = filedialog.asksaveasfilename(
+            title="Экспорт шифртекста ключа",
+            defaultextension=".txt",
+            filetypes=[("Текстовые файлы", "*.txt"), ("Все файлы", "*.*")],
+        )
+        if not path:
+            return
+
+        try:
+            with open(path, "w", encoding="utf-8") as handle:
+                handle.write(raw)
+        except OSError as error:
+            messagebox.showerror("Ошибка", f"Не удалось сохранить файл: {error}")
+            return
+
+        messagebox.showinfo("Готово", "Шифртекст ключа сохранён.")
+
+    def _import_ciphertext(self) -> None:
+        """Загрузить шифртекст сети Фейстеля из файла."""
+
+        path = filedialog.askopenfilename(
+            title="Импорт шифртекста",
+            filetypes=[("Текстовые файлы", "*.txt"), ("Все файлы", "*.*")],
+        )
+        if not path:
+            return
+
+        try:
+            with open(path, "r", encoding="utf-8") as handle:
+                data = handle.read().strip()
+        except OSError as error:
+            messagebox.showerror("Ошибка", f"Не удалось прочитать файл: {error}")
+            return
+
+        if not data:
+            messagebox.showerror("Ошибка", "Файл не содержит данных для импорта.")
+            return
+
+        self.ciphertext_var.set(data)
+        messagebox.showinfo("Готово", "Шифртекст загружен.")
+
+    def _export_ciphertext(self) -> None:
+        """Сохранить шифртекст сети Фейстеля в файл."""
+
+        data = self.ciphertext_var.get().strip()
+        if not data:
+            messagebox.showerror("Ошибка", "Нет шифртекста для экспорта.")
+            return
+
+        path = filedialog.asksaveasfilename(
+            title="Экспорт шифртекста",
+            defaultextension=".txt",
+            filetypes=[("Текстовые файлы", "*.txt"), ("Все файлы", "*.*")],
+        )
+        if not path:
+            return
+
+        try:
+            with open(path, "w", encoding="utf-8") as handle:
+                handle.write(data)
+        except OSError as error:
+            messagebox.showerror("Ошибка", f"Не удалось сохранить файл: {error}")
+            return
+
+        messagebox.showinfo("Готово", "Шифртекст сохранён.")
 
     # ------------------------------------------------------------------
     # Encryption / decryption logic

--- a/hybrid_crypto.py
+++ b/hybrid_crypto.py
@@ -9,6 +9,7 @@ the public exponent.
 
 from __future__ import annotations
 
+import json
 import math
 import secrets
 from dataclasses import dataclass
@@ -49,6 +50,55 @@ class RSAKeyPair:
 
     public: RSAPublicKey
     private: RSAPrivateKey
+
+
+def export_rsa_public_key(key: RSAPublicKey) -> str:
+    """Вернуть публичный ключ RSA в виде JSON-строки."""
+
+    # Используем строки для модуля, чтобы избежать переполнения при обмене.
+    payload = {"modulus": str(key.modulus), "exponent": str(key.exponent)}
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def export_rsa_private_key(key: RSAPrivateKey) -> str:
+    """Вернуть приватный ключ RSA в виде JSON-строки."""
+
+    payload = {"modulus": str(key.modulus), "exponent": str(key.exponent)}
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def import_rsa_public_key(data: str) -> RSAPublicKey:
+    """Восстановить публичный ключ RSA из текстового представления."""
+
+    try:
+        payload = json.loads(data)
+    except json.JSONDecodeError as error:
+        raise ValueError("Не удалось прочитать публичный ключ.") from error
+
+    try:
+        modulus = int(payload["modulus"])
+        exponent = int(payload.get("exponent", PUBLIC_EXPONENT))
+    except (KeyError, TypeError, ValueError) as error:
+        raise ValueError("Некорректный формат публичного ключа.") from error
+
+    return RSAPublicKey(modulus=modulus, exponent=exponent)
+
+
+def import_rsa_private_key(data: str) -> RSAPrivateKey:
+    """Восстановить приватный ключ RSA из текстового представления."""
+
+    try:
+        payload = json.loads(data)
+    except json.JSONDecodeError as error:
+        raise ValueError("Не удалось прочитать приватный ключ.") from error
+
+    try:
+        modulus = int(payload["modulus"])
+        exponent = int(payload["exponent"])
+    except (KeyError, TypeError, ValueError) as error:
+        raise ValueError("Некорректный формат приватного ключа.") from error
+
+    return RSAPrivateKey(modulus=modulus, exponent=exponent)
 
 
 def generate_rsa_keypair(prime_bits: int = RSA_DEFAULT_SIZE) -> RSAKeyPair:


### PR DESCRIPTION
## Summary
- add JSON serialization helpers for RSA ключи чтобы их можно было передавать и хранить
- переработать GUI: отдельные кнопки для генерации, импорта и экспорта ключей и шифртекста
- добавить функции чтения/записи файлов для шифртекста Feistel и RSA-ключа

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d2a665d4348324a025379c67acdc74