### PR TITLE
Add Docker Compose setup for Flask app

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+__pycache__/
+*.py[cod]
+*.pem
+*.json
+.env
+.git
+.gitignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        libffi-dev \
+        libssl-dev \
+        pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt ./
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+ENV FLASK_APP=app.py \
+    FLASK_RUN_HOST=0.0.0.0 \
+    FLASK_RUN_PORT=5000
+
+EXPOSE 5000
+
+CMD ["flask", "run", "--host=0.0.0.0", "--port=5000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,22 @@
-version: "3.9"
-
 services:
-  web:
-    build: .
-    container_name: feistels-network-app
-    ports:
-      - "2141:5000"
+  backend:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: feistel-backend
     restart: unless-stopped
+    networks:
+      - default
+      - proxy
+    labels:
+      - traefik.enable=true
+      - traefik.docker.network=proxy
+      - traefik.http.routers.feistel.rule=Host(`feistel.strdinc.space`)
+      - traefik.http.routers.feistel.entrypoints=websecure
+      - traefik.http.routers.feistel.tls=true
+      - traefik.http.routers.feistel.tls.certresolver=myresolver
+      - traefik.http.services.feistel.loadbalancer.server.port=5000
+
+networks:
+  proxy:
+    external: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: "3.9"
+
+services:
+  web:
+    build: .
+    container_name: feistels-network-app
+    ports:
+      - "2141:5000"
+    restart: unless-stopped


### PR DESCRIPTION
## Summary
- add a Dockerfile to containerize the Flask web application
- add a docker-compose configuration mapping port 2141 on the host to the app
- ignore common local files during Docker builds

## Testing
- python -m compileall app.py data_io.py feistel.py rsa_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68d2bc8da1548324a76f232ce5b96505